### PR TITLE
fix: my-library 리스트 페이지 스크롤 영역까지 배경 적용(#84)

### DIFF
--- a/src/app/(with-header)/(protected)/my-library/(list)/page.tsx
+++ b/src/app/(with-header)/(protected)/my-library/(list)/page.tsx
@@ -95,7 +95,7 @@ export default function MyLibraryPage() {
   }, [isMobile, loading, hasMore, fetchBooks])
 
   return (
-    <div className="h-screen">
+    <div className="min-h-screen">
       {/* 검색창 */}
       <div className="mb-8 space-y-4">
         <div className="flex gap-4">


### PR DESCRIPTION
## 📌 이슈 번호

> ex) #84

## 🚀 상세 설명

> my-library 리스트 페이지 h-screen → min-h-screen으로 변경해 스크롤 영역까지 배경 적용

## 📸 스크린샷

## 📢 노트
