### PR TITLE
fix: 내서재 로그인 로딩 실패 / 독후감 수정 저장 및 태그 로직 오류 수정

### DIFF
--- a/src/app/(with-header)/(protected)/my-library/(detail)/[id]/page.tsx
+++ b/src/app/(with-header)/(protected)/my-library/(detail)/[id]/page.tsx
@@ -111,6 +111,7 @@ export default function BookDetailPage() {
           : '독후감이 수정되었습니다.',
       )
       setShouldGoBack(true)
+      setDirty(false)
       setShowResultModal(true)
     } catch (e) {
       console.error('저장 실패:', e)
@@ -136,6 +137,7 @@ export default function BookDetailPage() {
       })
       setModalMessage('독후감이 삭제되었습니다.')
       setShouldGoBack(true)
+      setDirty(false)
       setShowResultModal(true)
     } catch (e) {
       console.error('삭제 실패:', e)
@@ -169,7 +171,9 @@ export default function BookDetailPage() {
           memo={memo}
           onChangeMemo={setMemo}
           tags={tags}
-          onAddTag={(t) => setTags((prev) => [...prev, t])}
+          onAddTag={(t) =>
+            setTags((prev) => Array.from(new Set([...prev, t])))
+          }
           onRemoveTag={(t) =>
             setTags((prev) => prev.filter((x) => x !== t))
           }

--- a/src/app/(with-header)/(protected)/my-library/(list)/page.tsx
+++ b/src/app/(with-header)/(protected)/my-library/(list)/page.tsx
@@ -54,6 +54,16 @@ export default function MyLibraryPage() {
   }, [fetchBooks])
 
   useEffect(() => {
+    const onFocus = () => {
+      if (!loading && books.length === 0) {
+        fetchBooks(true)
+      }
+    }
+    window.addEventListener('focus', onFocus)
+    return () => window.removeEventListener('focus', onFocus)
+  }, [fetchBooks, loading, books.length])
+
+  useEffect(() => {
     const mql = window.matchMedia('(max-width: 767px)')
     const onChange = (e: MediaQueryListEvent) =>
       setIsMobile(e.matches)

--- a/src/app/(with-header)/(protected)/my-library/_components/_detail/tag-input.tsx
+++ b/src/app/(with-header)/(protected)/my-library/_components/_detail/tag-input.tsx
@@ -78,6 +78,7 @@ export default function TagInput({
           >
             {t}
             <button
+              type="button"
               onClick={() => removeTag(t)}
               className="ml-1 hover:text-red-500 cursor-pointer"
             >


### PR DESCRIPTION
## 📌 이슈 번호

> ex) #161 

## 🚀 상세 설명

> [ 내서재 페이지 로딩 오류 ]
> 비로그인→로그인 후 ‘내 서재’가 빈 화면으로 남는 현상을 해결하기 위해, 브라우저 탭 포커스 이벤트(window.focus) 발생 시 fetchBooks(true)를 재호출하도록 로직 추가

> [독후감 페이지 뒤로가기 컨펌]
> 저장·삭제 처리 후 isDirty 상태를 false로 초기화하여, 저장 완료 직후 뒤로가기 버튼을 눌러도 불필요한 “저장하지 않았습니다” 모달이 뜨지 않도록 수정

> [태그 입력 컴포넌트 개선]
> 태그 삭제·추천 버튼에 type="button"을 명시해 기본 submit 동작을 차단
> onAddTag에서 Set을 사용해 빠른 클릭 시 중복 태그 등록 방지

## 📸 스크린샷

## 📢 노트
